### PR TITLE
Updates how role responses are managed

### DIFF
--- a/path_roles.go
+++ b/path_roles.go
@@ -96,10 +96,6 @@ func (b *backend) pathRoleList(ctx context.Context, req *logical.Request, _ *fra
 		return nil, err
 	}
 
-	if entries == nil {
-		return logical.ErrorResponse("no roles found"), nil
-	}
-
 	return logical.ListResponse(entries), nil
 }
 
@@ -200,7 +196,7 @@ func (b *backend) pathRoleRead(ctx context.Context, req *logical.Request, data *
 	}
 
 	if role == nil {
-		return logical.ErrorResponse("no such role"), nil
+		return nil, nil
 	}
 
 	return &logical.Response{

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// When there are no roles, an error must be returned.
+// When there are no roles, no error should be returned.
 func TestBackend_PathRoleList_Empty(t *testing.T) {
 	b, config := makeBackend(t)
 
@@ -22,7 +22,7 @@ func TestBackend_PathRoleList_Empty(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.NoError(t, err)
 	assert.Empty(t, resp.Warnings)
-	assert.True(t, resp.IsError())
+	assert.False(t, resp.IsError())
 }
 
 // The backend must be configured before it will accept roles


### PR DESCRIPTION
* Return `nil` when a role is not found to generate a 404 HTTP response instead of a 400
* Avoid returning an error when no roles are found

Resolves #5 