### PR TITLE
Draft: feat: rotate admin token

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -54,7 +54,8 @@ func Backend(_ *logical.BackendConfig) (*backend, error) {
 		b.pathListRoles(),
 		b.pathRoles(),
 		b.pathTokenCreate(),
-		b.pathConfig())
+		b.pathConfig(),
+		b.pathConfigRotate())
 
 	return b, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jfrog/artifactory-secrets-plugin
 go 1.17
 
 require (
+	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/vault/api v1.0.2
@@ -16,7 +17,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/frankban/quicktest v1.14.2 // indirect
-	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/frankban/quicktest v1.14.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 h1:28FVBuwkwowZMjbA7M0wXsI6t3PYulRTMio3SO+eKCM=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3a
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31 h1:28FVBuwkwowZMjbA7M0wXsI6t3PYulRTMio3SO+eKCM=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -3,7 +3,7 @@ package artifactory
 import (
 	"context"
 
-	"github.com/golang-jwt/jwt"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -25,12 +25,9 @@ This will rotate the "access_token" used to access artifactory from this plugin,
 }
 
 func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	b.Logger().Debug("START: pathConfigRotateWrite")
 	b.configMutex.Lock()
 	defer b.configMutex.Unlock()
-	b.rolesMutex.RLock()
-	b.configMutex.RLock()
-	defer b.configMutex.RUnlock()
-	defer b.rolesMutex.RUnlock()
 
 	config, err := b.fetchAdminConfiguration(ctx, req.Storage)
 	if err != nil {
@@ -41,19 +38,28 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	// Parse Current Token
+	oldAccessToken := config.AccessToken
+
+	// Parse Current Token (to get tokenID)
 	// -- NOTE THIS IGNORES THE SIGNATURE, which is probably bad,
-	//    but it is not our job to validate the token.
-	token, err := jwt.Parse(config.AccessToken, nil)
+	//    but it is not our job to validate the token, right?
+	p := jwt.Parser{}
+	token, _, err := p.ParseUnverified(oldAccessToken, jwt.MapClaims{})
 	if err != nil {
-		return logical.ErrorResponse("error parsing existing AccessToken"), nil
+		return logical.ErrorResponse("error parsing existing AccessToken: ", err.Error()), nil
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok || !token.Valid {
+	if !ok {
 		return logical.ErrorResponse("error parsing claims in existing AccessToken"), nil
 	}
-	oldTokenID := claims["jti"] // jti -> JFrog Token ID?
+	// SKIP: We are not validating the token, so it won't be valid :)
+	// if !token.Valid {
+	// 	b.Logger().Warn("While rotating, existing token seems to be invalid")
+	//  return logical.ErrorResponse("error parsing claims in existing AccessToken"), nil
+	// }
+	oldTokenID := claims["jti"] // jti -> JFrog Token ID
+	b.Logger().Debug("oldTokenID: " + oldTokenID.(string))
 
 	// Create admin role for the new token
 	role := &artifactoryRole{
@@ -62,18 +68,25 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	}
 
 	// Create a new token
+	b.Logger().Debug("pathConfigRotateWrite: create new token")
 	resp, err := b.createToken(*config, *role)
 	if err != nil {
-		return nil, err
+		return logical.ErrorResponse("error parsing claims in existing AccessToken"), err
 	}
 
 	// Set new token
 	config.AccessToken = resp.AccessToken
 
 	// Invalidate Old Token (TODO)
-	err = b.revokeToken(*config, oldTokenID.(logical.Secret))
+	oldSecret := logical.Secret{
+		InternalData: map[string]interface{}{
+			"access_token": config.AccessToken,
+			"token_id":     oldTokenID,
+		},
+	}
+	err = b.revokeToken(*config, oldSecret)
 	if err != nil {
-		return logical.ErrorResponse("error revoking existing AccessToken"), nil
+		return logical.ErrorResponse("error revoking existing AccessToken"), err
 	}
 
 	// Save new config

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -1,0 +1,91 @@
+package artifactory
+
+import (
+	"context"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) pathConfigRotate() *framework.Path {
+	return &framework.Path{
+		Pattern: "config/rotate",
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathConfigRotateWrite,
+				Summary:  "Rotate the Artifactory Admin Token.",
+			},
+		},
+		HelpSynopsis: `Rotate the Artifactory Admin Token.`,
+		HelpDescription: `
+This will rotate the "access_token" used to access artifactory from this plugin, and remove the old token.
+`,
+	}
+}
+
+func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	b.configMutex.Lock()
+	defer b.configMutex.Unlock()
+	b.rolesMutex.RLock()
+	b.configMutex.RLock()
+	defer b.configMutex.RUnlock()
+	defer b.rolesMutex.RUnlock()
+
+	config, err := b.fetchAdminConfiguration(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	if config == nil {
+		return logical.ErrorResponse("backend not configured"), nil
+	}
+
+	// Parse Current Token
+	// -- NOTE THIS IGNORES THE SIGNATURE, which is probably bad,
+	//    but it is not our job to validate the token.
+	token, err := jwt.Parse(config.AccessToken, nil)
+	if err != nil {
+		return logical.ErrorResponse("error parsing existing AccessToken"), nil
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return logical.ErrorResponse("error parsing claims in existing AccessToken"), nil
+	}
+	oldTokenID := claims["jti"] // jti -> JFrog Token ID?
+
+	// Create admin role for the new token
+	role := &artifactoryRole{
+		Username: "admin",
+		Scope:    "applied-permissions/admin",
+	}
+
+	// Create a new token
+	resp, err := b.createToken(*config, *role)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set new token
+	config.AccessToken = resp.AccessToken
+
+	// Invalidate Old Token (TODO)
+	err = b.revokeToken(*config, oldTokenID.(logical.Secret))
+	if err != nil {
+		return logical.ErrorResponse("error revoking existing AccessToken"), nil
+	}
+
+	// Save new config
+	entry, err := logical.StorageEntryJSON("config/admin", config)
+	if err != nil {
+		return nil, err
+	}
+
+	err = req.Storage.Put(ctx, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
Closes #14 

This should setup the ability to "rotate" the admin token after setting it. This means that we can immediately revoke the admin token that was "known" (at least by the pipeline script), and only Vault itself will know the admin token it is using.

This has not been fully tested, this is a request for "review" and comments.