### PR TITLE
chore: Cleanup options, lint and consistency - Also fix testing against non https URLs

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -19,17 +19,17 @@ func TestBackend_CreateTokenSuccess(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://myserver.com/artifactory/api/system/version",
+		"http://myserver.com/artifactory/api/system/version",
 		httpmock.NewStringResponder(200, artVersion))
 
 	httpmock.RegisterResponder(
 		"POST",
-		"https://myserver.com/artifactory/api/security/token",
+		"http://myserver.com/artifactory/api/security/token",
 		httpmock.NewStringResponder(200, canonicalAccessToken))
 
 	b, config := configuredBackend(t, map[string]interface{}{
 		"access_token": "test-access-token",
-		"url":          "https://myserver.com/artifactory",
+		"url":          "http://myserver.com/artifactory",
 	})
 
 	// Setup a role
@@ -291,22 +291,22 @@ func TestBackend_RotateAdminToken(t *testing.T) {
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://myserver.com/artifactory/api/system/version",
+		"http://myserver.com/artifactory/api/system/version",
 		httpmock.NewStringResponder(200, `{"version" : "7.33.8", "revision" : "73308900"}`))
 
 	httpmock.RegisterResponder(
 		"GET",
-		"https://myserver.com/access/api/v1/cert/root",
+		"http://myserver.com/access/api/v1/cert/root",
 		httpmock.NewStringResponder(200, rootCert))
 
 	httpmock.RegisterResponder(
 		"POST",
-		"https://myserver.com/access/api/v1/tokens",
+		"http://myserver.com/access/api/v1/tokens",
 		httpmock.NewStringResponder(200, jwtAccessToken))
 
 	httpmock.RegisterResponder(
 		"DELETE",
-		"https://myserver.com/access/api/v1/tokens/fe3e6322-eb6d-468e-8445-c790113278c0",
+		"http://myserver.com/access/api/v1/tokens/fe3e6322-eb6d-468e-8445-c790113278c0",
 		httpmock.NewStringResponder(200, ""))
 
 	// Valid jwt Access Token
@@ -325,7 +325,7 @@ func TestBackend_RotateAdminToken(t *testing.T) {
 			`qHdAEivER-5ZrXsTFGX4dqym4NuSN6WsW-0eUdTb8gwI4FfVJGtqdwRUkbnX_gg3CCwOS` +
 			`Cqy5kl48WBdqwv9GyPVmnO4fafIJ-8oAqh9vCaD8lB0MHjFFciwEMggoaucLlQZ15yPuT` +
 			`aK9Zr82EigQMM-g`,
-		"url": "https://myserver.com/artifactory",
+		"url": "http://myserver.com/artifactory",
 	})
 
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{


### PR DESCRIPTION
Several things:

* Fixed a couple lint issues (`if newRequest == true`)
* Fixed ability to work with non-https URLs, very useful for acceptance testing on minikube.
  * I am not sure what the `tls.Dial()` is really for, it says "tls verification" but it seems like that would be handled by the http request? 
* Since the URL was being parsed in the "perform*" methods anyhow, there was no need to pass "host" separately. 
  * It is still being parsed twice, due to the "option" to deploy artifactory to some path other than /artifactory?? is that a thing?
* Removed the word "Request" from the performArtifactory* methods, renamed:
  * `performArtifactoryRequest` --> `performArtifactoryPost`
  * `performArtifactoryDelRequest` --> `performArtifactoryDelete`
  * (part of #16 ) added `performArtifactoryGet`
* Made all occurrences of test server "http(s)://myserver.com" simply "http://myserver.com" which should obviate the need to have that in the code. (of course I think that whole tls.Dial() is unnecessary)


Comments?