### PR TITLE
feat: use env variables during make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 GOARCH = amd64
+ACCESS_TOKEN ?= $(shell printenv ACCESS_TOKEN || echo 'access_token')
+ARTIFACTORY_URL ?= $(shell printenv ARTIFACTORY_URL || echo 'http://localhost:8080')
+ARTIFACTORY_SCOPE ?= $(shell printenv ARTIFACTORY_SCOPE || echo 'applied-permissions/groups:readers')
 
 UNAME = $(shell uname -s)
 
@@ -33,9 +36,9 @@ fmt:
 	go fmt $$(go list ./...)
 
 setup:	enable
-	vault write artifactory/config/admin url=http://localhost:8080 access_token=access_token
+	vault write artifactory/config/admin url=$(ARTIFACTORY_URL) access_token=$(ACCESS_TOKEN)
 	vault read artifactory/config/admin
-	vault write artifactory/roles/test scope="test" username="test-user" max_ttl=3h default_ttl=2h
+	vault write artifactory/roles/test scope="$(ARTIFACTORY_SCOPE)" username="test-user" max_ttl=3h default_ttl=2h
 	vault read artifactory/roles/test
 
 artifactory:


### PR DESCRIPTION
This just allows you to set useful environment variables like `ARTIFACTORY_URL` and `ACCESS_TOKEN` to allow `make setup` to work.