### PR TITLE
feat: more token information on config read

### DIFF
--- a/artifactory.go
+++ b/artifactory.go
@@ -224,6 +224,34 @@ func (b *backend) parseJWT(config adminConfiguration, token string) (jwtToken *j
 	return
 }
 
+// getTokenInfo will parse the provided token to return useful information about it
+func (b *backend) getTokenInfo(config adminConfiguration, token string) (info map[string]string, err error) {
+	// Parse Current Token (to get tokenID/scope)
+	jwtToken, err := b.parseJWT(config, token)
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("error parsing claims in AccessToken")
+	}
+
+	sub := strings.Split(claims["sub"].(string), "/") // sub -> subject (jfac@01fr1x1h805xmg0t17xhqr1v7a/users/admin)
+
+	info = map[string]string{
+		"TokenID":  claims["jti"].(string), // jti -> JFrog Token ID
+		"Scope":    claims["scp"].(string), // scp -> scope
+		"Username": sub[len(sub)-1],        // last element of subject
+	}
+	return
+}
+
+// getAdminTokenInfo will return tokenInfo for the currently configured AccessToken
+func (b *backend) getAdminTokenInfo(config adminConfiguration) (info map[string]string, err error) {
+	return b.getTokenInfo(config, config.AccessToken)
+}
+
 // getRootCert will return the Artifactory access root certificate's public key, for validating token signatures
 func (b *backend) getRootCert(config adminConfiguration) (cert *x509.Certificate, err error) {
 	// Verify Artifactory version is at 7.12.0 or higher, prior versions will not work

--- a/artifactory.go
+++ b/artifactory.go
@@ -247,11 +247,6 @@ func (b *backend) getTokenInfo(config adminConfiguration, token string) (info ma
 	return
 }
 
-// getAdminTokenInfo will return tokenInfo for the currently configured AccessToken
-func (b *backend) getAdminTokenInfo(config adminConfiguration) (info map[string]string, err error) {
-	return b.getTokenInfo(config, config.AccessToken)
-}
-
 // getRootCert will return the Artifactory access root certificate's public key, for validating token signatures
 func (b *backend) getRootCert(config adminConfiguration) (cert *x509.Certificate, err error) {
 	// Verify Artifactory version is at 7.12.0 or higher, prior versions will not work

--- a/path_config.go
+++ b/path_config.go
@@ -121,7 +121,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, _ *f
 	}
 
 	// Optionally include token info if it parses properly
-	token, err := b.getAdminTokenInfo(*config)
+	token, err := b.getTokenInfo(*config, config.AccessToken)
 	if err != nil {
 		b.Logger().Warn("Error parsing AccessToken: " + err.Error())
 	} else {

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -39,7 +39,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	oldAccessToken := config.AccessToken
 
 	// Parse Current Token (to get tokenID/scope)
-	token, err := b.getAdminTokenInfo(*config)
+	token, err := b.getTokenInfo(*config, oldAccessToken)
 	if err != nil {
 		return logical.ErrorResponse("error parsing existing AccessToken: " + err.Error()), err
 	}

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -2,9 +2,7 @@ package artifactory
 
 import (
 	"context"
-	"strings"
 
-	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -41,35 +39,26 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	oldAccessToken := config.AccessToken
 
 	// Parse Current Token (to get tokenID/scope)
-	token, err := b.parseJWT(*config, oldAccessToken)
+	token, err := b.getAdminTokenInfo(*config)
 	if err != nil {
 		return logical.ErrorResponse("error parsing existing AccessToken: " + err.Error()), err
 	}
 
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return logical.ErrorResponse("error parsing claims in existing AccessToken"), nil
+	if len(token["Username"]) == 0 {
+		token["Username"] = "admin" // default username to admin if not found, not sure if this is needed
 	}
-
-	oldTokenID := claims["jti"].(string)              // jti -> JFrog Token ID
-	scope := claims["scp"].(string)                   // scp -> scope
-	sub := strings.Split(claims["sub"].(string), "/") // sub -> subject (jfac@01fr1x1h805xmg0t17xhqr1v7a/users/admin)
-	username := "admin"                               // default to admin
-	if len(sub) > 0 {
-		username = sub[len(sub)-1]
-	}
-	b.Logger().Debug("oldTokenID: " + oldTokenID)
+	b.Logger().Debug("oldToken ID: " + token["TokenID"])
 
 	// Create admin role for the new token
 	role := &artifactoryRole{
-		Username: username,
-		Scope:    scope,
+		Username: token["Username"],
+		Scope:    token["Scope"],
 	}
 
 	// Create a new token
 	resp, err := b.createToken(*config, *role)
 	if err != nil {
-		return logical.ErrorResponse("error parsing claims in existing AccessToken"), err
+		return logical.ErrorResponse("error creating new token"), err
 	}
 	b.Logger().Debug("newTokenID: " + resp.TokenId)
 
@@ -87,11 +76,11 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 		return nil, err
 	}
 
-	// Invalidate Old Token (TODO)
+	// Invalidate Old Token
 	oldSecret := logical.Secret{
 		InternalData: map[string]interface{}{
 			"access_token": oldAccessToken,
-			"token_id":     oldTokenID,
+			"token_id":     token["TokenID"],
 		},
 	}
 	err = b.revokeToken(*config, oldSecret)


### PR DESCRIPTION
Show more useful token information when reading config. SHA256 is not useful after rotating token, show username, token_id and scope.

Example

```
$ vault read artifactory/config/admin
Key                    Value
---                    -----
access_token_sha256    def0def11280a56e538876459fe5bbef1ad15cb5acd25251aa57eccb8eb4eb34
jfrog_token_id         d1edc4a9-c3c9-4ff7-82f2-d0d24b44780a
scope                  applied-permissions/admin
url                    https://artifactory.company.com
username               tommy-test-vault
```

Fixes #36 