### PR TITLE
feat: include tokenId in revoke errors

### DIFF
--- a/artifactory.go
+++ b/artifactory.go
@@ -60,8 +60,8 @@ func (b *backend) revokeToken(config adminConfiguration, secret logical.Secret) 
 	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		b.Backend.Logger().Warn("got non-200 status code", "statusCode", resp.StatusCode)
+	if resp.StatusCode >= http.StatusBadRequest {
+		b.Backend.Logger().Warn("revokeToken got bad http status code", "statusCode", resp.StatusCode)
 		return fmt.Errorf("could not revoke tokenID: %v - HTTP response %v", tokenId, resp.StatusCode)
 	}
 

--- a/artifactory.go
+++ b/artifactory.go
@@ -46,14 +46,14 @@ func (b *backend) revokeToken(config adminConfiguration, secret logical.Secret) 
 	if newAccessReq {
 		resp, err = b.performArtifactoryDelete(config, "/access/api/v1/tokens/"+tokenId)
 		if err != nil {
-			b.Backend.Logger().Warn("error deleting access token", "response", resp, "err", err)
+			b.Backend.Logger().Warn("error deleting access tokenID", tokenId, "response", resp, "err", err)
 			return err
 		}
 
 	} else {
 		resp, err = b.performArtifactoryPost(config, u.Path+"/api/security/token/revoke", values)
 		if err != nil {
-			b.Backend.Logger().Warn("error deleting token", "response", resp, "err", err)
+			b.Backend.Logger().Warn("error deleting tokenID", tokenId, "response", resp, "err", err)
 			return err
 		}
 	}
@@ -62,7 +62,7 @@ func (b *backend) revokeToken(config adminConfiguration, secret logical.Secret) 
 
 	if resp.StatusCode != http.StatusOK {
 		b.Backend.Logger().Warn("got non-200 status code", "statusCode", resp.StatusCode)
-		return fmt.Errorf("could not revoke token: HTTP response %v", resp.StatusCode)
+		return fmt.Errorf("could not revoke tokenID: %v - HTTP response %v", tokenId, resp.StatusCode)
 	}
 
 	return nil

--- a/artifactory.go
+++ b/artifactory.go
@@ -46,14 +46,14 @@ func (b *backend) revokeToken(config adminConfiguration, secret logical.Secret) 
 	if newAccessReq {
 		resp, err = b.performArtifactoryDelete(config, "/access/api/v1/tokens/"+tokenId)
 		if err != nil {
-			b.Backend.Logger().Warn("error deleting access tokenID", tokenId, "response", resp, "err", err)
+			b.Backend.Logger().Warn("error deleting access token", "tokenId", tokenId, "response", resp, "err", err)
 			return err
 		}
 
 	} else {
 		resp, err = b.performArtifactoryPost(config, u.Path+"/api/security/token/revoke", values)
 		if err != nil {
-			b.Backend.Logger().Warn("error deleting tokenID", tokenId, "response", resp, "err", err)
+			b.Backend.Logger().Warn("error deleting token", "tokenId", tokenId, "response", resp, "err", err)
 			return err
 		}
 	}


### PR DESCRIPTION
We have seen some errors revoking tokens

```
lease revocation failed: lease_id=artifactory/token/jenkins/2y6wgde6HysH32XXt7h0Nccd.RmD7j error="failed to revoke entry: resp: (*logical.Response)(nil) err: could not revoke token: HTTP response 204"
```

... and would like to see the tokenId in the response.

This would tell us whether the tokens are actually being revoked or not, and would also give us a way to take action based on the error (manually revoke by ID)

See also: Support Case #238590

I am requesting clarification (since we can't actually see artifactory code) as to what "204" means in this case. I am leaning towards 204 being a "tokenId does not exist" 404? We may want to handle a "204" as a success.