### PR TITLE
feat: real artifactory for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ----------------------------------------------------------------
 
-This plugin is now being actively maintained by JFrog Inc. Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for contributions and create github issues to ask for support
------------------------------------------------------------------
+This plugin is now being actively maintained by JFrog Inc.Please refer to [CONTRIBUTING.md](CONTRIBUTING.md) for contributions and create github issues to ask for support
 
-![Build](https://github.com/idcmp/artifactory-secrets-plugin/workflows/Build/badge.svg)
+----------------------------------------------------------------
+
+![Build](https://github.com/jfrog/artifactory-secrets-plugin/actions/workflows/build.yml/badge.svg)
 
 This is a [HashiCorp Vault](https://www.vaultproject.io/) plugin which talks to JFrog Artifactory server and will
 dynamically provision access tokens with specified scopes. This backend can be mounted multiple times
@@ -26,25 +27,47 @@ This backend creates access tokens in Artifactory using the admin credentials pr
 
 ## Testing Locally
 
-If you're compiling this yourself and want to do a local sanity test, you
-can do something like:
+If you're compiling this yourself and want to test locally, you will need a working docker environment. You will also need vault and golang installed, then you can follow the steps below.
 
-In first terminal, build the plugin and start the local dev server:
+* In first terminal, build the plugin and start the local dev server:
+
 ```sh
 make
 ```
 
-In another terminal, setup the vault with values:
+* In another terminal, setup a test artifactory instance. If you want to test a specific version, you can set `ARTIFACTORY_VERSION` environment variable.
+
 ```sh
-export VAULT_ADDR=http://127.0.0.1:8200
-export VAULT_TOKEN=root
-make setup
+make artifactory
 ```
 
-Once that's completed, in the same terminal:
 ```sh
-make artifactory &  # Runs netcat returning a static JSON response
+make artifactory ARTIFACTORY_VERSION=7.52.3
+```
+
+* Then, setup artifactory-secrets-engine in vault with values:
+
+```sh
+export VAULT_ADDR=http://localhost:8200
+export VAULT_token=root
+make setup
 vault read artifactory/token/test
+```
+
+NOTE: Each time you rebuild (making changes?), you will need to run `make setup` again, since vault is in dev mode.
+
+* Once you are done testing, you can destroy the local artifactory instance:
+
+```sh
+make stop_artifactory
+```
+
+If you would like to test against another artifactory:
+
+```sh
+export ARTIFACTORY_URL=https://artifactory.example.com
+export JFROG_ACCESS_TOKEN=(PASTE YOUR JFROG ADMIN TOKEN)
+make setup
 ```
 
 ## Installation

--- a/scripts/get-access-key.sh
+++ b/scripts/get-access-key.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Generate an admin access token
+# Heavily borrowed from: https://github.com/jfrog/terraform-provider-artifactory/blob/master/scripts/get-access-key.sh
+
+set -eu
+
+function getAccessKey() {
+  url=${1:-http://localhost:8082}
+  USERNAME=${USERNAME:-admin}
+  PASSWORD=${PASSWORD:-password}
+  TOKEN_USERNAME=${TOKEN_USERNAME:-admin}
+  echo "### Generate Admin Access Key ###" > /dev/stderr
+
+  local cookies
+  cookies=$(curl -s -c - "${url}/ui/api/v1/ui/auth/login?_spring_security_remember_me=false" \
+                --header "accept: application/json, text/plain, */*" \
+                --header "content-type: application/json;charset=UTF-8" \
+                --header "x-requested-with: XMLHttpRequest" \
+                -d '{"user":"'$USERNAME'","password":"'$PASSWORD'","type":"login"}' | grep TOKEN)
+
+  local refresh_token
+  refresh_token=$(echo "${cookies}" | grep REFRESHTOKEN | awk '{print $7 }')
+
+  local access_token
+  access_token=$(echo "${cookies}" | grep ACCESSTOKEN | awk '{print $7 }')
+
+  local access_key
+  local scoped_access_key
+  access_key=$(curl -s -g --request GET "${url}/ui/api/v1/system/security/token?services[]=all" \
+                --header "accept: application/json, text/plain, */*" \
+                --header "x-requested-with: XMLHttpRequest" \
+                --header "cookie: ACCESSTOKEN=${access_token}; REFRESHTOKEN=${refresh_token}")
+
+  curl -s --location --request POST "${url}/access/api/v1/tokens" \
+    --header "Authorization: Bearer ${access_key}" \
+    --header "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "expires_in=3600" \
+    --data-urlencode "username=${TOKEN_USERNAME}" \
+    --data-urlencode "scope=applied-permissions/admin" \
+    --data-urlencode "description=Created_with_script_during_provisioning" | jq -er .access_token
+  }
+
+getAccessKey $*

--- a/scripts/run-artifactory-container.sh
+++ b/scripts/run-artifactory-container.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+## Heavily borrowed from: https://github.com/jfrog/terraform-provider-artifactory/tree/master/scripts
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+source "${SCRIPT_DIR}/wait-for-rt.sh"
+
+ARTIFACTORY_REPO="${ARTIFACTORY_REPO:-releases-docker.jfrog.io/jfrog}"
+ARTIFACTORY_IMAGE="${ARTIFACTORY_IMAGE:-artifactory-jcr}"
+ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.55.2}
+echo "ARTIFACTORY_IMAGE=${ARTIFACTORY_IMAGE}" > /dev/stderr
+echo "ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION}" > /dev/stderr
+
+if [ -f "${SCRIPT_DIR}/artifactory.lic" ]; then
+  ARTIFACTORY_LICENSE="-v \"${SCRIPT_DIR}/artifactory.lic:/artifactory_extra_conf/artifactory.lic:ro\""
+else
+  ARTIFACTORY_LICENSE=""
+fi
+
+set -euf
+
+CONTAINER_ID=$(docker run -i -t -d --rm ${ARTIFACTORY_LICENSE} -p8081:8081 -p8082:8082 -p8080:8080 \
+  "${ARTIFACTORY_REPO}/${ARTIFACTORY_IMAGE}:${ARTIFACTORY_VERSION}")
+
+export ARTIFACTORY_URL=http://localhost:8081
+export ARTIFACTORY_UI_URL=http://localhost:8082
+
+# Wait for Artifactory to start
+waitForArtifactory "${ARTIFACTORY_URL}" "${ARTIFACTORY_UI_URL}"
+
+# With this trick you can do $(./run-artifactory-container.sh) and it will directly be setup for you without the terminal output
+echo "export ARTIFACTORY_CONTAINER_ID=${CONTAINER_ID}"
+echo "export ARTIFACTORY_URL=\"${ARTIFACTORY_UI_URL}\""

--- a/scripts/wait-for-rt.sh
+++ b/scripts/wait-for-rt.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function waitForArtifactory() {
+  local url=${1?You must supply the artifactory url}
+  local url_ui=${2?You must supply the artifactory UI url}
+  echo "### Wait for Artifactory to start ###" > /dev/stderr
+
+  until curl -sf -o /dev/null -u admin:password ${url}/artifactory/api/system/ping/; do
+      printf '.' > /dev/stderr
+      sleep 4
+  done
+  echo "" > /dev/stderr
+
+  echo "### Waiting for Artifactory UI to start ###" > /dev/stderr
+  until curl -sf -o /dev/null -u admin:password ${url_ui}/ui/login/; do
+      printf '.' > /dev/stderr
+      sleep 4
+  done
+  echo "" > /dev/stderr
+}


### PR DESCRIPTION
This uses the artifactory-jcr  container to create a local dev artifactory instance.

It also uses the magic scripts (with some edits) from the terraform provider to get an access key.

Closes #38 