### PR TITLE
Switch to use GoReleaser for local build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.17
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,8 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    # use 'go tool nm <path_to_binary> | grep Version' to find the Version variable path
+    - '-s -w -X github.com/jfrog/artifactory-secrets-plugin.Version=v{{ .Version }}'
   goos:
     - freebsd
     - windows
@@ -27,7 +28,9 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  binary: '{{ .ProjectName }}'
+snapshot:
+  name_template: '{{ .Version }}'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,16 @@ enable:
 	vault secrets enable artifactory
 
 register: build
-	vault plugin register -sha256=$$(sha256sum ${PLUGIN_DIR}/${PLUGIN_FILE} | cut -d " " -f 1) ${PLUGIN_FILE}
+	vault plugin register -sha256=$$(sha256sum ${PLUGIN_DIR}/${PLUGIN_FILE} | cut -d " " -f 1) -command=${PLUGIN_FILE} secret artifactory
+
+deregister:
+	value plugin deregister -version=${NEXT_VERSION} secret artifactory
 	
 upgrade: register
 	vault plugin reload -plugin=artifactory
 
 clean:
-	rm -f ./vault/plugins/artifactory
+	rm -f ${PLUGIN_DIR}/${PLUGIN_FILE}
 
 fmt:
 	go fmt $$(go list ./...)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Once the server is started, register the plugin in the Vault server's [plugin ca
 ```sh
 vault plugin register \
   -sha256=$(sha256sum path/to/plugin/directory/artifactory | cut -d " " -f 1) \
+  -command=artifactory-secrets-plugin \
   secret artifactory
 ```
 

--- a/backend.go
+++ b/backend.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+var Version = "v1.0.0"
+
 type backend struct {
 	*framework.Backend
 	configMutex      sync.RWMutex
@@ -56,7 +58,8 @@ func Backend(_ *logical.BackendConfig) (*backend, error) {
 	b.usernameProducer = up
 
 	b.Backend = &framework.Backend{
-		Help: strings.TrimSpace(artifactoryHelp),
+		Help:           strings.TrimSpace(artifactoryHelp),
+		RunningVersion: Version,
 
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{"config/admin"},


### PR DESCRIPTION
Closes #33 

This ensure both local and release build use identical toolchain.

- Removed version string from binary file name (now `artifactory-secrets-plugin`, vs `artifactory-secrets-plugin_v0.2.6`)
- Add `Version` variable to allow setting its value during build. This variable in turn is assigned to the backend's `RunningVersion` (i.e. plugin's version).