### PR TITLE
Add acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.idea
 /vendor
 
-
+.DS_Store
 dist/
+coverage.txt

--- a/.jfrog-pipelines/pipeline.yml
+++ b/.jfrog-pipelines/pipeline.yml
@@ -84,11 +84,10 @@ pipelines:
             - export REFRESHTOKEN=$(echo $COOKIES | grep REFRESHTOKEN | awk '{print $7}')
             - export ACCESSTOKEN=$(echo $COOKIES | grep ACCESSTOKEN | awk '{print $14}') # awk returns null on Mac, and the actual key on Ubuntu
             - >-
-              export ACCESS_KEY=$(curl -g --request GET "${JFROG_URL}/ui/api/v1/system/security/token?services[]=all" \
-                                  --header "accept: application/json, text/plain, */*" \
-                                  --header "x-requested-with: XMLHttpRequest" \
-                                  --header "cookie: ACCESSTOKEN=${ACCESSTOKEN}; REFRESHTOKEN=${REFRESHTOKEN}")
-            - add_run_variables ARTIFACTORY_ACCESS_TOKEN=${ACCESS_KEY}
+              export ARTIFACTORY_ACCESS_TOKEN=$(curl -g --request GET "${JFROG_URL}/ui/api/v1/system/security/token?services[]=all" \
+                                             --header "accept: application/json, text/plain, */*" \
+                                             --header "x-requested-with: XMLHttpRequest" \
+                                             --header "cookie: ACCESSTOKEN=${ACCESSTOKEN}; REFRESHTOKEN=${REFRESHTOKEN}")
             - make acceptance
           onSuccess:
             - echo "Success"

--- a/.jfrog-pipelines/pipeline.yml
+++ b/.jfrog-pipelines/pipeline.yml
@@ -48,7 +48,48 @@ pipelines:
             - git branch && ls -al
             - add_run_variables PLUGIN_VERSION=$(git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
             - export NEXT_VERSION=${PLUGIN_VERSION} && echo ${NEXT_VERSION}
-            - make test
+            - echo "Set Artifactory version, run RT in a container"
+            - helm repo add artifactory https://charts.jfrog.io
+            - helm repo update
+            - add_run_variables ARTIFACTORY_VERSION=$(helm search repo | grep "artifactory " | awk '{$1=$1};1' |  cut -f3 -d " ")
+            - echo "Artifactory version: "${ARTIFACTORY_VERSION}
+            - export ARTIFACTORY_CONTAINER_NAME=artifactory
+            - >-
+              docker run -i --name ${ARTIFACTORY_CONTAINER_NAME} -t -d --rm -v "${res_GitHubTFProviderRepoJFrog_resourcePath}/scripts/artifactory.lic:/artifactory_extra_conf/artifactory.lic:ro" \
+                    -p8081:8081 -p8082:8082 -p8080:8080 releases-docker.jfrog.io/jfrog/artifactory-pro:${ARTIFACTORY_VERSION}
+            - echo "Set localhost to a container IP address, since we run docker inside of docker"
+            - export LOCALHOST=$(docker inspect -f '{{`{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}`}}' ${ARTIFACTORY_CONTAINER_NAME})
+            - echo "Using ${LOCALHOST} as 'localhost' ip address"
+            - echo "Waiting for Artifactory to start (doesn't reflect the start of the UI!)"
+            - >-
+              until curl -sf -u admin:password http://${LOCALHOST}:8081/artifactory/api/system/licenses/; do
+                  printf '.'
+                  sleep 4
+              done
+            - echo "Add variables needed to run Terraform Provider"
+            - export JFROG_URL="http://${LOCALHOST}:8082"
+            - echo "Get cookie to generate Access token. We need a pause to let UI come up to get cookies"
+            - >-
+              until curl -sf -o /dev/null -u admin:password ${JFROG_URL}/ui/login/; do
+                  printf '.' > /dev/stderr
+                  sleep 4
+              done
+            - sudo curl http://${LOCALHOST}:8082/router/api/v1/system/health
+            - >-
+              export COOKIES=$(curl -c - "${JFROG_URL}/ui/api/v1/ui/auth/login?_spring_security_remember_me=false" \
+                            --header "accept: application/json, text/plain, */*" \
+                            --header "content-type: application/json;charset=UTF-8" \
+                            --header "x-requested-with: XMLHttpRequest" \
+                            -d '{"user":"admin","password":"'"password"'","type":"login"}' | grep FALSE)
+            - export REFRESHTOKEN=$(echo $COOKIES | grep REFRESHTOKEN | awk '{print $7}')
+            - export ACCESSTOKEN=$(echo $COOKIES | grep ACCESSTOKEN | awk '{print $14}') # awk returns null on Mac, and the actual key on Ubuntu
+            - >-
+              export ACCESS_KEY=$(curl -g --request GET "${JFROG_URL}/ui/api/v1/system/security/token?services[]=all" \
+                                  --header "accept: application/json, text/plain, */*" \
+                                  --header "x-requested-with: XMLHttpRequest" \
+                                  --header "cookie: ACCESSTOKEN=${ACCESSTOKEN}; REFRESHTOKEN=${REFRESHTOKEN}")
+            - add_run_variables ARTIFACTORY_ACCESS_TOKEN=${ACCESS_KEY}
+            - make acceptance
           onSuccess:
             - echo "Success"
             - export STATE="success"

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ build: fmt
 start:
 	vault server -dev -dev-root-token-id=root -dev-plugin-dir=${PLUGIN_DIR} -log-level=DEBUG
 
-test:
-	go test -v ./...
-
 disable:
 	vault secrets disable artifactory
 
@@ -48,6 +45,13 @@ deregister:
 	
 upgrade: register
 	vault plugin reload -plugin=artifactory
+
+test:
+	go test -v ./...
+
+acceptance:
+	export VAULT_ACC=true && \
+		go test -run TestAcceptance -cover -coverprofile=coverage.txt -v -p 1 -timeout 5m ./...
 
 clean:
 	rm -f ${PLUGIN_DIR}/${PLUGIN_FILE}

--- a/README.md
+++ b/README.md
@@ -425,6 +425,16 @@ make testrole
 
 ----------------------------------------------------------------
 
+#### Run Acceptance Tests
+
+```sh
+make acceptance
+```
+
+This requires the following:
+* A running Artifactory instance
+* Env vars `ARTIFACTORY_URL` and `JFROG_ACCESS_TOKEN` for the running Artifactory instance be set
+
 ## Issues
 
 * RTFACT-22477 - proposing CIDR restrictions on the created access tokens.

--- a/artifactory.go
+++ b/artifactory.go
@@ -25,7 +25,7 @@ const (
 
 var ErrIncompatibleVersion = errors.New("incompatible version")
 
-func (b *backend) revokeToken(config adminConfiguration, secret logical.Secret) error {
+func (b *backend) RevokeToken(config adminConfiguration, secret logical.Secret) error {
 
 	accessToken := secret.InternalData["access_token"].(string)
 	tokenId := secret.InternalData["token_id"].(string)
@@ -81,7 +81,7 @@ type CreateTokenRequest struct {
 	ForceRevocable bool   `json:"force_revocable,omitempty"`
 }
 
-func (b *backend) createToken(config adminConfiguration, role artifactoryRole) (*createTokenResponse, error) {
+func (b *backend) CreateToken(config adminConfiguration, role artifactoryRole) (*createTokenResponse, error) {
 	request := CreateTokenRequest{
 		GrantType: role.GrantType,
 		Username:  role.Username,

--- a/backend.go
+++ b/backend.go
@@ -46,6 +46,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 
 	return b, nil
 }
+
 func Backend(_ *logical.BackendConfig) (*backend, error) {
 	b := &backend{
 		httpClient: http.DefaultClient,

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -56,7 +56,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	}
 
 	// Create a new token
-	resp, err := b.createToken(*config, *role)
+	resp, err := b.CreateToken(*config, *role)
 	if err != nil {
 		return logical.ErrorResponse("error creating new token"), err
 	}
@@ -83,7 +83,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 			"token_id":     token.TokenID,
 		},
 	}
-	err = b.revokeToken(*config, oldSecret)
+	err = b.RevokeToken(*config, oldSecret)
 	if err != nil {
 		return logical.ErrorResponse("error revoking existing AccessToken"), err
 	}

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -1,0 +1,18 @@
+package artifactory
+
+import (
+	"testing"
+)
+
+func TestAcceptanceBackend_PathRotate(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accTestEnv.RotatePathConfig(t)
+}

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAcceptanceBackend_PathConfig(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("update", accTestEnv.UpdatePathConfig)
+	t.Run("read", accTestEnv.ReadPathConfig)
+	t.Run("delete", accTestEnv.DeletePathConfig)
+}
+
 func TestBackend_AccessTokenRequired(t *testing.T) {
 	b, config := makeBackend(t)
 
@@ -62,6 +77,10 @@ func TestBackend_AccessTokenAsSHA256(t *testing.T) {
 		"GET",
 		"http://myserver.com:80/artifactory/api/system/version",
 		httpmock.NewStringResponder(200, artVersion))
+	httpmock.RegisterResponder(
+		"GET",
+		"http://myserver.com:80/access/api/v1/cert/root",
+		httpmock.NewStringResponder(200, rootCert))
 
 	b, config := configuredBackend(t, map[string]interface{}{
 		"access_token": "test-access-token",

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAcceptanceBackend_PathRole(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("configure backend", accTestEnv.UpdatePathConfig)
+	t.Run("create", accTestEnv.CreatePathRole)
+	t.Run("read", accTestEnv.ReadPathRole)
+	t.Run("delete", accTestEnv.DeletePathRole)
+	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
+}
+
 // When there are no roles, no error should be returned.
 func TestBackend_PathRoleList_Empty(t *testing.T) {
 	b, config := makeBackend(t)

--- a/path_token_create.go
+++ b/path_token_create.go
@@ -105,7 +105,7 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 		ttl = role.MaxTTL
 	}
 
-	resp, err := b.createToken(*config, *role)
+	resp, err := b.CreateToken(*config, *role)
 	if err != nil {
 		return nil, err
 	}

--- a/path_token_create_test.go
+++ b/path_token_create_test.go
@@ -1,0 +1,22 @@
+package artifactory
+
+import (
+	"testing"
+)
+
+func TestAcceptanceBackend_PathTokenCreate(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("configure backend", accTestEnv.UpdatePathConfig)
+	t.Run("create role", accTestEnv.CreatePathRole)
+	t.Run("create token for role", accTestEnv.CreatePathToken)
+	t.Run("delete role", accTestEnv.DeletePathRole)
+	t.Run("cleanup backend", accTestEnv.DeletePathConfig)
+}

--- a/secret_access_token.go
+++ b/secret_access_token.go
@@ -84,7 +84,7 @@ func (b *backend) secretAccessTokenRevoke(ctx context.Context, req *logical.Requ
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	if err := b.revokeToken(*config, *req.Secret); err != nil {
+	if err := b.RevokeToken(*config, *req.Secret); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Built upon acceptance tests example from https://developer.hashicorp.com/vault/tutorials/custom-secrets-engine/custom-secrets-engine-creds#explore-acceptance-tests-that-verify-the-credentials-path

* Add acceptance tests
* Add command to Makefile
* Update README
* Add spinning up Artifactory container to Pipeline config for acceptance tests.