### PR TITLE
fix: dont emit empty strings when reading role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ PLUGIN_PATH ?= artifactory
 
 ARTIFACTORY_ENV := ./vault/artifactory.env
 ARTIFACTORY_SCOPE ?= applied-permissions/groups:readers
-ARTIFACTORY_URL ?= http://localhost:8082
-JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) ARTIFACTORY_URL=$(ARTIFACTORY_URL) ./scripts/getArtifactoryAdminToken.sh)
+export ARTIFACTORY_URL ?= http://localhost:8082
+export JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) ARTIFACTORY_URL=$(ARTIFACTORY_URL) ./scripts/getArtifactoryAdminToken.sh)
 TOKEN_USERNAME ?= vault-admin
 UNAME = $(shell uname -s)
 export VAULT_TOKEN ?= root

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ NEXT_VERSION := $(shell echo ${CURRENT_VERSION}| awk -F '.' '{print $$1 "." $$2 
 
 PLUGIN_DIR=dist/artifactory-secrets-plugin_${GORELEASER_ARCH}
 PLUGIN_FILE=artifactory-secrets-plugin
+PLUGIN_PATH ?= artifactory
 
 ARTIFACTORY_ENV := ./vault/artifactory.env
 ARTIFACTORY_SCOPE ?= applied-permissions/groups:readers
@@ -18,8 +19,8 @@ ARTIFACTORY_URL ?= http://localhost:8082
 JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) ARTIFACTORY_URL=$(ARTIFACTORY_URL) ./scripts/getArtifactoryAdminToken.sh)
 TOKEN_USERNAME ?= vault-admin
 UNAME = $(shell uname -s)
-VAULT_TOKEN ?= $(shell printenv VAULT_TOKEN || echo 'root')
-VAULT_ADDR ?= $(shell printenv VAULT_ADDR || echo 'http://localhost:8200')
+export VAULT_TOKEN ?= root
+export VAULT_ADDR ?= http://localhost:8200
 
 .DEFAULT_GOAL := all
 
@@ -32,19 +33,19 @@ start:
 	vault server -dev -dev-root-token-id=root -dev-plugin-dir=${PLUGIN_DIR} -log-level=DEBUG
 
 disable:
-	vault secrets disable artifactory
+	vault secrets disable ${PLUGIN_PATH}
 
 enable:
-	vault secrets enable artifactory
+	vault secrets enable -path=${PLUGIN_PATH} ${PLUGIN_FILE}
 
 register: build
-	vault plugin register -sha256=$$(sha256sum ${PLUGIN_DIR}/${PLUGIN_FILE} | cut -d " " -f 1) -command=${PLUGIN_FILE} secret artifactory
+	vault plugin register -sha256=$$(sha256sum ${PLUGIN_DIR}/${PLUGIN_FILE} | cut -d " " -f 1) -command=${PLUGIN_FILE} secret ${PLUGIN_FILE}
 
 deregister:
-	value plugin deregister -version=${NEXT_VERSION} secret artifactory
+	value plugin deregister -version=${NEXT_VERSION} secret ${PLUGIN_FILE}
 	
 upgrade: register
-	vault plugin reload -plugin=artifactory
+	vault plugin reload -plugin=${PLUGIN_FILE}
 
 test:
 	go test -v ./...
@@ -62,15 +63,15 @@ fmt:
 setup: disable enable admin testrole
 
 admin:
-	vault write artifactory/config/admin url=$(ARTIFACTORY_URL) access_token=$(JFROG_ACCESS_TOKEN)
-	vault read artifactory/config/admin
-	vault write -f artifactory/config/rotate
-	vault read artifactory/config/admin
+	vault write ${PLUGIN_PATH}/config/admin url=$(ARTIFACTORY_URL) access_token=$(JFROG_ACCESS_TOKEN)
+	vault read ${PLUGIN_PATH}/config/admin
+	vault write -f ${PLUGIN_PATH}/config/rotate
+	vault read ${PLUGIN_PATH}/config/admin
 
 testrole:
-	vault write artifactory/roles/test scope="$(ARTIFACTORY_SCOPE)" max_ttl=3h default_ttl=2h
-	vault read artifactory/roles/test
-	vault read artifactory/token/test
+	vault write ${PLUGIN_PATH}/roles/test scope="$(ARTIFACTORY_SCOPE)" max_ttl=3h default_ttl=2h
+	vault read ${PLUGIN_PATH}/roles/test
+	vault read ${PLUGIN_PATH}/token/test
 
 artifactory: $(ARTIFACTORY_ENV)
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,21 @@ username           v-jenkins-x4mohTA8
 
 ## Development
 
+### Local Development Prerequisites
+
+* Vault
+  * <https://developer.hashicorp.com/vault/docs/install>
+  * `brew install vault`
+* Golang
+  * <https://go.dev/doc/install>
+  * `brew install golang`
+* GoReleaser - Used during the build process
+  *  <https://goreleaser.com/install/>
+  * `brew install goreleaser`
+* Docker - To run a test Artifactory instance (very useful for testing)
+  * <https://docs.docker.com/get-docker/>
+  * `brew install docker --cask`
+
 ### Testing Locally
 
 If you're compiling this yourself and want to test locally, you will need a working docker environment. You will also need vault and golang installed, then you can follow the steps below.
@@ -283,7 +298,7 @@ make artifactory
 
 ```sh
 export VAULT_ADDR=http://localhost:8200
-export VAULT_token=root
+export VAULT_TOKEN=root
 make setup
 ```
 

--- a/path_roles.go
+++ b/path_roles.go
@@ -78,7 +78,7 @@ func (b *backend) pathRoles() *framework.Path {
 }
 
 type artifactoryRole struct {
-	GrantType  string        `json:"grant_type"`
+	GrantType  string        `json:"grant_type,omitempty"`
 	Username   string        `json:"username,omitempty"`
 	Scope      string        `json:"scope"`
 	Audience   string        `json:"audience,omitempty"`
@@ -218,16 +218,26 @@ func (b *backend) Role(ctx context.Context, storage logical.Storage, roleName st
 	return &role, nil
 }
 
-func (b *backend) roleToMap(roleName string, role artifactoryRole) map[string]interface{} {
-	return map[string]interface{}{
+func (b *backend) roleToMap(roleName string, role artifactoryRole) (roleMap map[string]interface{}) {
+	roleMap = map[string]interface{}{
 		"role":        roleName,
-		"grant_type":  role.GrantType,
-		"username":    role.Username,
 		"scope":       role.Scope,
-		"audience":    role.Audience,
 		"default_ttl": role.DefaultTTL.Seconds(),
 		"max_ttl":     role.MaxTTL.Seconds(),
 	}
+
+	// Optional Attributes
+	if len(role.GrantType) > 0 {
+		roleMap["grant_type"] = role.GrantType
+	}
+	if len(role.Username) > 0 {
+		roleMap["username"] = role.Username
+	}
+	if len(role.Audience) > 0 {
+		roleMap["audience"] = role.Audience
+	}
+
+	return
 }
 
 func (b *backend) pathRoleDelete(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {


### PR DESCRIPTION
Now when the role is read, it looks like:

```console
$ vault read artifactory/roles/test
Key            Value
---            -----
default_ttl    2h
max_ttl        3h
role           test
scope          applied-permissions/groups:readers
```