### PR TITLE
fix: dont export JFROG_ACCESS_TOKEN till needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PLUGIN_PATH ?= artifactory
 ARTIFACTORY_ENV := ./vault/artifactory.env
 ARTIFACTORY_SCOPE ?= applied-permissions/groups:readers
 export JFROG_URL ?= http://localhost:8082
-export JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) JFROG_URL=$(JFROG_URL) ./scripts/getArtifactoryAdminToken.sh)
+JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) JFROG_URL=$(JFROG_URL) ./scripts/getArtifactoryAdminToken.sh)
 TOKEN_USERNAME ?= vault-admin
 UNAME = $(shell uname -s)
 export VAULT_TOKEN ?= root
@@ -54,6 +54,7 @@ test:
 
 acceptance:
 	export VAULT_ACC=true && \
+	export JFROG_ACCESS_TOKEN=$(JFROG_ACCESS_TOKEN) && \
 		go test -run TestAcceptance -cover -coverprofile=coverage.txt -v -p 1 -timeout 5m ./...
 
 clean:


### PR DESCRIPTION
This fixes the strange activity where make commands try to get a token for jobs that don't need it.

```console
$ make stop_artifactory
Logging in to Artifactory (http://localhost:8082) as admin ...
curl: (7) Failed to connect to localhost port 8082 after 7 ms: Couldn't connect to server
Failed to login to Artifactory
```