### PR TITLE
fix: parsing of admin usernames with /

### DIFF
--- a/artifactory.go
+++ b/artifactory.go
@@ -280,9 +280,9 @@ func (b *backend) getTokenInfo(config adminConfiguration, token string) (info *T
 	sub := strings.Split(claims["sub"].(string), "/") // sub -> subject (jfac@01fr1x1h805xmg0t17xhqr1v7a/users/admin)
 
 	info = &TokenInfo{
-		TokenID:  claims["jti"].(string), // jti -> JFrog Token ID
-		Scope:    claims["scp"].(string), // scp -> scope
-		Username: sub[len(sub)-1],        // last element of subject
+		TokenID:  claims["jti"].(string),     // jti -> JFrog Token ID
+		Scope:    claims["scp"].(string),     // scp -> scope
+		Username: strings.Join(sub[2:], "/"), // 3rd+ elements (incase username has / in it)
 	}
 
 	// exp -> expires at (unixtime) - may not be present


### PR DESCRIPTION
Fixes Allow for "username" parameter on /config/rotate to change token username #69


```console
[tmcneely@local artifactory-secrets-plugin]$ TOKEN_USERNAME="learning-center/tommy-mcneely-vault-admin" make admin
Logging in to Artifactory (http://localhost:8082) as admin ...
Generating artifactory admin access token.
vault write artifactory/config/admin url=http://localhost:8082 access_token=eyJ2ZXIiOiIyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYiLCJraWQiOiJoTDNOaER2VHdENWpZOG4xMktiZ2ZycExfcDlGMnNUZ2dFYlRId2U0dGdNIn0.eyJzdWIiOiJqZmFjQDAxZ3lqeXM5eXdqeHRzMG0xeWUxbTgxejAxXC91c2Vyc1wvbGVhcm5pbmctY2VudGVyXC90b21teS1tY25lZWx5LXZhdWx0LWFkbWluIiwic2NwIjoiYXBwbGllZC1wZXJtaXNzaW9uc1wvYWRtaW4iLCJhdWQiOiIqQCoiLCJpc3MiOiJqZmZlQDAxZ3lqeXM5eXdqeHRzMG0xeWUxbTgxejAxIiwiZXhwIjoxNjgyMTQ2OTE3LCJpYXQiOjE2ODIxMTgxMTcsImp0aSI6ImRjZTY0MGJmLTQwZDUtNGJiOC05NDZjLWZlNWViMzhlZmIxMSJ9.fVlSqyMamkygYryDt00KNNvYJPx_6yJtoRutxPMpbjVup8eW3tLbgqeVH8vtTILwlZt1E34WmvH8_TBQo5WgMwKznHaaFJXJ-mQvtTVO9uqvA507mg01V--SPh7QknysHYwUehZsabPrZPac9RPSFc7V73-AyyyXVuoZqyoWIBju-iyLpWqiRl_VQD5ciFpxi4j2Dp0gU_WnI72yqfjYCZBz-epl1cHBSh-lmdFuNZ6kTl5XaqBhMrVlda4GK64ks7cpGLw9fPnrc24ecSMZzINAtItUTkwIzu2gvRS-7FWeRvgCW36_sgDbau4_EpzIzE3cy0HFW5nouYrBETNgQg
Logging in to Artifactory (http://localhost:8082) as admin ...
Generating artifactory admin access token.
Success! Data written to: artifactory/config/admin
vault read artifactory/config/admin
Key                    Value
---                    -----
access_token_sha256    4424b6ce7c96c3e5221412cd595d13debe70031796f35d997ea2e47abda8caef
exp                    1682146917
expires                2023-04-22T01:01:57-06:00
scope                  applied-permissions/admin
token_id               dce640bf-40d5-4bb8-946c-fe5eb38efb11
url                    http://localhost:8082
use_expiring_tokens    false
username               learning-center/tommy-mcneely-vault-admin
version                7.55.10
vault write -f artifactory/config/rotate
Success! Data written to: artifactory/config/rotate
vault read artifactory/config/admin
Key                    Value
---                    -----
access_token_sha256    2224d75355fdb05ada4ce9a980c2ea8f4c92cd1ec890855b517aa1beec0529eb
scope                  applied-permissions/admin
token_id               5784be1d-46bd-4733-ba04-a13b22066a40
url                    http://localhost:8082
use_expiring_tokens    false
username               learning-center/tommy-mcneely-vault-admin
version                7.55.10
```