### PR TITLE
More makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
-GO_ARCH=$(shell go env GOARCH)
-TARGET_ARCH=$(shell go env GOOS)_${GO_ARCH}
-GORELEASER_ARCH=${TARGET_ARCH}
+GO_ARCH := $(shell go env GOARCH)
+TARGET_ARCH := $(shell go env GOOS)_$(GO_ARCH)
+GORELEASER_ARCH := $(TARGET_ARCH)
 
 ifeq ($(GO_ARCH), amd64)
-GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
+GORELEASER_ARCH := $(TARGET_ARCH)_$(shell go env GOAMD64)
 endif
 
-GIT_SHORT_HASH=$(shell git rev-parse --short HEAD)
-CURRENT_VERSION?=$(shell git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
-NEXT_VERSION := $(shell echo ${CURRENT_VERSION} | awk -F '.' '{print $$1 "." $$2 "." $$3 +1}')-dev+${GIT_SHORT_HASH}
+GIT_SHORT_HASH := $(shell git rev-parse --short HEAD)
+CURRENT_VERSION := $(shell git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
+NEXT_VERSION := $(shell echo $(CURRENT_VERSION) | awk -F '.' '{print $$1 "." $$2 "." $$3 +1}')-dev+$(GIT_SHORT_HASH)
 
-PLUGIN_DIR=dist/artifactory-secrets-plugin_${GORELEASER_ARCH}
-PLUGIN_FILE=artifactory-secrets-plugin
-PLUGIN_PATH ?= artifactory
+PLUGIN_DIR := dist/artifactory-secrets-plugin_$(GORELEASER_ARCH)
+PLUGIN_FILE := artifactory-secrets-plugin
+PLUGIN_NAME ?= artifactory
+PLUGIN_VAULT_PATH ?= artifactory
 
 ARTIFACTORY_ENV := ./vault/artifactory.env
 ARTIFACTORY_SCOPE ?= applied-permissions/groups:readers
 export JFROG_URL ?= http://localhost:8082
 JFROG_ACCESS_TOKEN ?= $(shell TOKEN_USERNAME=$(TOKEN_USERNAME) JFROG_URL=$(JFROG_URL) ./scripts/getArtifactoryAdminToken.sh)
 TOKEN_USERNAME ?= vault-admin
-UNAME = $(shell uname -s)
 export VAULT_TOKEN ?= root
 export VAULT_ADDR ?= http://localhost:8200
 
@@ -28,26 +28,26 @@ export VAULT_ADDR ?= http://localhost:8200
 all: fmt build test start
 
 build: fmt
-	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
+	GORELEASER_CURRENT_TAG=$(NEXT_VERSION) goreleaser build --single-target --clean --snapshot
 
 start:
-	vault server -dev -dev-root-token-id=root -dev-plugin-dir=${PLUGIN_DIR} -log-level=DEBUG
+	vault server -dev -dev-root-token-id=root -dev-plugin-dir=$(PLUGIN_DIR) -log-level=DEBUG
 
 disable:
-	vault secrets disable ${PLUGIN_PATH}
+	vault secrets disable $(PLUGIN_VAULT_PATH)
 
 enable:
-	vault secrets enable -path=${PLUGIN_PATH} -plugin-version=${NEXT_VERSION} ${PLUGIN_FILE}
+	vault secrets enable -path=$(PLUGIN_VAULT_PATH) -plugin-version=$(NEXT_VERSION) $(PLUGIN_NAME)
 
-register: build
-	vault plugin register -sha256=$$(sha256sum ${PLUGIN_DIR}/${PLUGIN_FILE} | cut -d " " -f 1) -command=${PLUGIN_FILE} -version=${NEXT_VERSION} secret ${PLUGIN_FILE}
-	vault plugin info -version=${NEXT_VERSION} secret ${PLUGIN_FILE}
+register:
+	vault plugin register -sha256=$$(sha256sum $(PLUGIN_DIR)/$(PLUGIN_FILE) | cut -d " " -f 1) -command=$(PLUGIN_FILE) -version=$(NEXT_VERSION) secret $(PLUGIN_NAME)
+	vault plugin info -version=$(NEXT_VERSION) secret $(PLUGIN_NAME)
 
 deregister:
-	vault plugin deregister -version=${NEXT_VERSION} secret ${PLUGIN_FILE}
+	vault plugin deregister -version=$(NEXT_VERSION) secret $(PLUGIN_NAME)
 	
-upgrade: register
-	vault plugin reload -plugin=${PLUGIN_FILE}
+upgrade: build register
+	vault plugin reload -plugin=$(PLUGIN_NAME)
 
 test:
 	go test -v ./...
@@ -58,23 +58,23 @@ acceptance:
 		go test -run TestAcceptance -cover -coverprofile=coverage.txt -v -p 1 -timeout 5m ./...
 
 clean:
-	rm -f ${PLUGIN_DIR}/${PLUGIN_FILE}
+	rm -f $(PLUGIN_DIR)/$(PLUGIN_FILE)
 
 fmt:
 	go fmt $$(go list ./...)
 
-setup: disable enable admin testrole
+setup: disable register enable admin testrole
 
 admin:
-	vault write ${PLUGIN_PATH}/config/admin url=$(JFROG_URL) access_token=$(JFROG_ACCESS_TOKEN)
-	vault read ${PLUGIN_PATH}/config/admin
-	vault write -f ${PLUGIN_PATH}/config/rotate
-	vault read ${PLUGIN_PATH}/config/admin
+	vault write $(PLUGIN_VAULT_PATH)/config/admin url=$(JFROG_URL) access_token=$(JFROG_ACCESS_TOKEN)
+	vault read $(PLUGIN_VAULT_PATH)/config/admin
+	vault write -f $(PLUGIN_VAULT_PATH)/config/rotate
+	vault read $(PLUGIN_VAULT_PATH)/config/admin
 
 testrole:
-	vault write ${PLUGIN_PATH}/roles/test scope="$(ARTIFACTORY_SCOPE)" max_ttl=3h default_ttl=2h
-	vault read ${PLUGIN_PATH}/roles/test
-	vault read ${PLUGIN_PATH}/token/test
+	vault write $(PLUGIN_VAULT_PATH)/roles/test scope="$(ARTIFACTORY_SCOPE)" max_ttl=3h default_ttl=2h
+	vault read $(PLUGIN_VAULT_PATH)/roles/test
+	vault read $(PLUGIN_VAULT_PATH)/token/test
 
 artifactory: $(ARTIFACTORY_ENV)
 
@@ -85,4 +85,4 @@ stop_artifactory:
 	source $(ARTIFACTORY_ENV) && docker stop $$ARTIFACTORY_CONTAINER_ID
 	rm -f $(ARTIFACTORY_ENV)
 
-.PHONY: build clean fmt start disable enable test setup admin testrole artifactory stop_artifactory
+.PHONY: build clean fmt start disable enable register deregister upgrade test acceptance  setup admin testrole artifactory stop_artifactory

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ vault write artifactory/config/admin use_expiring_tokens=true
 * Example Token Output:
 
 ```console
-$ ACCESS_TOKEN=$(vault read -field access_tokeartifactory/token/test)
+$ ACCESS_TOKEN=$(vault read -field access_token artifactory/token/test)
 $ jwt decode $ACCESS_TOKEN
 
 Token header
@@ -140,8 +140,6 @@ You can now enable the Artifactory secrets plugin:
 vault secrets enable artifactory
 ```
 
-## Usage
-
 ### Artifactory
 
 1. Log into the Artifactory UI as an "admin".
@@ -201,6 +199,8 @@ use_expiring_tokens    false
 username               vault-admin
 version                7.55.6
 ```
+
+## Usage
 
 * Create a role (scope for artifactory >= 7.21.1)
 


### PR DESCRIPTION
I noticed that `make upgrade` was not working. I also noticed that the plugin name was "artifactory-secrets-plugin" instead of "artifactory" so I tried to work on that.

- [x] Makefile variables that are static should use `:=`, especially ones that use shell commands to evaluate
- [x] consistent interpolation, I think Makefile recommends using `$(VAR_NAME)` (rather than curly braces which can sometimes be mistaken for shell variables)
- [x] make register - only register
- [x] make upgrade (add build that was part of register)
- [x] update PHONY
- [x] Set PLUGIN_NAME separately from PLUGIN_FILE (to prevent future filename changes from affecting as much)
- [x] make plugin name artifactory (instead of artifactory-secrets-engine)
- [x] Make the "dev/test" procedure more closely match the intended use case (README)
- [x] make setup needs to register (if plugin name is artifactory)
