### PR TITLE
feat: allow setting username/description during rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ vault write -f artifactory/config/rotate
 
 **NOTE** some versions of artifactory (notably `7.39.10`) fail to rotate correctly. As noted above, we recommend being on `7.42.1` or higher. The token was indeed rotated, but as the error indicates, the old token could not be revoked.
 
+**ALSO** If you want to change the username for the admin token (tired of it just being "admin"?) or set a "Description" on the token, those parameters are optionally
+available on the `artifactory/config/rotate` endpoint.
+
+> `vault write artifactory/config/rotate username="new-username" description="A token used by vault-secrets-engine on our vault server"`
+
 * OPTIONAL: Check the results:
 
 ```sh

--- a/artifactory.go
+++ b/artifactory.go
@@ -83,10 +83,11 @@ type CreateTokenRequest struct {
 
 func (b *backend) CreateToken(config adminConfiguration, role artifactoryRole) (*createTokenResponse, error) {
 	request := CreateTokenRequest{
-		GrantType: role.GrantType,
-		Username:  role.Username,
-		Scope:     role.Scope,
-		Audience:  role.Audience,
+		GrantType:   role.GrantType,
+		Username:    role.Username,
+		Scope:       role.Scope,
+		Audience:    role.Audience,
+		Description: role.Description,
 	}
 
 	if len(request.Username) == 0 {

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -56,15 +56,12 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 
 	// Check for submitted username
 	if val, ok := data.GetOk("username"); ok {
-		b.Logger().Debug("old username: " + token.Username)
 		token.Username = val.(string)
-		b.Logger().Debug("new username: " + token.Username)
 	}
 
 	if len(token.Username) == 0 {
 		token.Username = "admin-vault-secrets-artifactory" // default username if empty
 	}
-	b.Logger().Debug("oldToken ID: " + token.TokenID)
 
 	// Create admin role for the new token
 	role := &artifactoryRole{
@@ -82,7 +79,6 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	if err != nil {
 		return logical.ErrorResponse("error creating new token"), err
 	}
-	b.Logger().Debug("newTokenID: " + resp.TokenId)
 
 	// Set new token
 	config.AccessToken = resp.AccessToken

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -72,6 +72,8 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 	// Check for new description
 	if val, ok := data.GetOk("description"); ok {
 		role.Description = val.(string)
+	} else {
+		role.Description = "Rotated Admin token for artifactory-secrets plugin in Vault"
 	}
 
 	// Create a new token

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -28,11 +28,7 @@ func (b *backend) pathConfigRotate() *framework.Path {
 		},
 		HelpSynopsis: `Rotate the Artifactory Admin Token.`,
 		HelpDescription: `
-This will rotate the "access_token" used to access artifactory from this plugin, and remove the old token.
-
-An optional "username" parameter will override the current username when generating the new admin token.
-
-An optional "description" parameter will set the description when generating the new admin token.
+This will rotate the "access_token" used to access artifactory from this plugin, and revoke the old admin token.
 `,
 	}
 }
@@ -58,8 +54,11 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 		return logical.ErrorResponse("error parsing existing AccessToken: " + err.Error()), err
 	}
 
+	// Check for submitted username
 	if val, ok := data.GetOk("username"); ok {
+		b.Logger().Debug("old username: " + token.Username)
 		token.Username = val.(string)
+		b.Logger().Debug("new username: " + token.Username)
 	}
 
 	if len(token.Username) == 0 {

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -12,33 +12,28 @@ func TestAcceptanceBackend_PathRotate(t *testing.T) {
 	}
 
 	e := NewConfiguredAcceptanceTestEnv(t)
-	before := e.ReadConfigAdmin(t)
-	e.UpdateConfigRotate(t, testData{}) // empty write
-	after := e.ReadConfigAdmin(t)
-
-	assert.NotEmpty(t, after["access_token_sha256"])
-	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
+	t.Run("empty", e.PathConfigRotateEmpty)
+	t.Run("withDetails", e.PathConfigRotateWithDetails)
 	e.Cleanup(t)
 }
 
-func TestAcceptanceBackend_PathRotateWithDetails(t *testing.T) {
-	if !runAcceptanceTests {
-		t.SkipNow()
-	}
+func (e *accTestEnv) PathConfigRotateEmpty(t *testing.T) {
+	before := e.ReadConfigAdmin(t)
+	e.UpdateConfigRotate(t, testData{}) // empty write
+	after := e.ReadConfigAdmin(t)
+	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
+}
 
+func (e *accTestEnv) PathConfigRotateWithDetails(t *testing.T) {
 	newUsername := "vault-acceptance-test-changed"
 	description := "Artifactory Secrets Engine Accceptance Test"
-
-	e := NewConfiguredAcceptanceTestEnv(t)
 	before := e.ReadConfigAdmin(t)
 	e.UpdateConfigRotate(t, testData{
 		"username":    newUsername,
 		"description": description,
 	})
 	after := e.ReadConfigAdmin(t)
-
 	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
 	assert.Equal(t, newUsername, after["username"])
 	// Not testing Description, because it is not returned in the token (yet)
-	e.Cleanup(t)
 }

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -18,6 +18,7 @@ func TestAcceptanceBackend_PathRotate(t *testing.T) {
 
 	assert.NotEmpty(t, after["access_token_sha256"])
 	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
+	e.Cleanup(t)
 }
 
 func TestAcceptanceBackend_PathRotateWithDetails(t *testing.T) {

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -16,3 +16,16 @@ func TestAcceptanceBackend_PathRotate(t *testing.T) {
 
 	accTestEnv.RotatePathConfig(t)
 }
+
+func TestAcceptanceBackend_PathRotateWithDetails(t *testing.T) {
+	if !runAcceptanceTests {
+		t.SkipNow()
+	}
+
+	accTestEnv, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accTestEnv.RotatePathConfigWithDetails(t)
+}

--- a/path_roles.go
+++ b/path_roles.go
@@ -78,12 +78,13 @@ func (b *backend) pathRoles() *framework.Path {
 }
 
 type artifactoryRole struct {
-	GrantType  string        `json:"grant_type,omitempty"`
-	Username   string        `json:"username,omitempty"`
-	Scope      string        `json:"scope"`
-	Audience   string        `json:"audience,omitempty"`
-	DefaultTTL time.Duration `json:"default_ttl,omitempty"`
-	MaxTTL     time.Duration `json:"max_ttl,omitempty"`
+	GrantType   string        `json:"grant_type,omitempty"`
+	Username    string        `json:"username,omitempty"`
+	Scope       string        `json:"scope"`
+	Audience    string        `json:"audience,omitempty"`
+	Description string        `json:"description,omitempty"`
+	DefaultTTL  time.Duration `json:"default_ttl,omitempty"`
+	MaxTTL      time.Duration `json:"max_ttl,omitempty"`
 }
 
 func (b *backend) pathRoleList(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {

--- a/test_utils.go
+++ b/test_utils.go
@@ -25,6 +25,8 @@ type accTestEnv struct {
 	Storage logical.Storage
 }
 
+type testData map[string]interface{}
+
 // createNewTestToken creates a new scoped token using the one from test environment
 // so that the original token won't be revoked by the path config rotate test
 func (e *accTestEnv) createNewTestToken(t *testing.T) (string, string) {
@@ -77,14 +79,19 @@ func (e *accTestEnv) revokeTestToken(t *testing.T, accessToken string, tokenID s
 }
 
 func (e *accTestEnv) UpdatePathConfig(t *testing.T) {
-	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
+	e.UpdateConfigAdmin(t, testData{
+		"access_token": e.AccessToken,
+		"url":          e.URL,
+	})
+}
+
+// UpdateConfigAdmin will send a POST/PUT to the /config/admin endpoint with testData (vault write artifactory/config/admin)
+func (e *accTestEnv) UpdateConfigAdmin(t *testing.T, data testData) {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "config/admin",
 		Storage:   e.Storage,
-		Data: map[string]interface{}{
-			"access_token": e.AccessToken,
-			"url":          e.URL,
-		},
+		Data:      data,
 	})
 
 	assert.NoError(t, err)
@@ -92,7 +99,12 @@ func (e *accTestEnv) UpdatePathConfig(t *testing.T) {
 }
 
 func (e *accTestEnv) ReadPathConfig(t *testing.T) {
-	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
+	_ = e.ReadConfigAdmin(t)
+}
+
+// ReadConfigAdmin will send a GET to the /config/admin endpoint (vault read artifactory/config/admin)
+func (e *accTestEnv) ReadConfigAdmin(t *testing.T) testData {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.ReadOperation,
 		Path:      "config/admin",
 		Storage:   e.Storage,
@@ -101,10 +113,16 @@ func (e *accTestEnv) ReadPathConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Data["access_token_sha256"])
+	return resp.Data
 }
 
 func (e *accTestEnv) DeletePathConfig(t *testing.T) {
-	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
+	e.DeleteConfigAdmin(t)
+}
+
+// DeleteConfigAdmin will send a DELETE to the /config/admin endpoint (vault delete artifactory/config/admin)
+func (e *accTestEnv) DeleteConfigAdmin(t *testing.T) {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.DeleteOperation,
 		Path:      "config/admin",
 		Storage:   e.Storage,
@@ -114,146 +132,17 @@ func (e *accTestEnv) DeletePathConfig(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-func (e *accTestEnv) RotatePathConfig(t *testing.T) {
-	// create new test token
-	tokenID, accessToken := e.createNewTestToken(t)
-
-	// setup new path configuration
-	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-		Data: map[string]interface{}{
-			"access_token": accessToken,
-			"url":          e.URL,
-		},
-	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
-
-	// read back the path configuration and save the access token hash for comparison later
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.NotEmpty(t, resp.Data["access_token_sha256"])
-
-	accessTokenHash := resp.Data["access_token_sha256"]
-
-	// rotate the path config
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
+// UpdateConfigRotate will send a POST/PUT to the /config/rotate endpoint with testData (vault write artifactory/config/rotate)
+func (e *accTestEnv) UpdateConfigRotate(t *testing.T, data testData) {
+	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "config/rotate",
 		Storage:   e.Storage,
+		Data:      data,
 	})
 
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
-
-	// read back the path configuration and assert access token hash is now different
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.NotEmpty(t, resp.Data["access_token_sha256"])
-	assert.NotEqual(t, accessTokenHash, resp.Data["access_token_sha256"])
-
-	// clean up path config
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.DeleteOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
-
-	// revoke the test token
-	e.revokeTestToken(t, accessToken, tokenID)
-}
-
-func (e *accTestEnv) RotatePathConfigWithDetails(t *testing.T) {
-	// create new test token
-	tokenID, accessToken := e.createNewTestToken(t)
-
-	// setup new path configuration
-	resp, err := e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-		Data: map[string]interface{}{
-			"access_token": accessToken,
-			"url":          e.URL,
-		},
-	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
-
-	// read back the path configuration and save the access token hash for comparison later
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.NotEmpty(t, resp.Data["access_token_sha256"])
-
-	accessTokenHash := resp.Data["access_token_sha256"]
-
-	// rotate the token with a username and description
-	var newUsername = "new-vault-admin-user"
-	var description = "Artifactory Secrets Engine Admin Token"
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config/rotate",
-		Storage:   e.Storage,
-		Data: map[string]interface{}{
-			"username":    newUsername,
-			"description": description,
-		},
-	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
-
-	// read back the path configuration and assert access token hash is now different
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.NotEmpty(t, resp.Data["access_token_sha256"])
-	assert.NotEqual(t, accessTokenHash, resp.Data["access_token_sha256"])
-	assert.Equal(t, newUsername, resp.Data["username"])
-	// Not testing description because it is not in the token, but it could be queried from the access API
-
-	// clean up path config
-	resp, err = e.Backend.HandleRequest(context.Background(), &logical.Request{
-		Operation: logical.DeleteOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
-
-	// revoke the test token
-	e.revokeTestToken(t, accessToken, tokenID)
 }
 
 func (e *accTestEnv) CreatePathRole(t *testing.T) {
@@ -321,6 +210,15 @@ func (e *accTestEnv) CreatePathToken(t *testing.T) {
 	assert.Equal(t, "applied-permissions/user", resp.Data["scope"])
 }
 
+// Cleanup will delete the admin configuration and revoke the token
+func (e *accTestEnv) Cleanup(t *testing.T) {
+	data := e.ReadConfigAdmin(t)
+	e.DeleteConfigAdmin(t)
+
+	// revoke the test token
+	e.revokeTestToken(t, e.AccessToken, data["token_id"].(string))
+}
+
 func newAcceptanceTestEnv() (*accTestEnv, error) {
 	ctx := context.Background()
 
@@ -339,6 +237,25 @@ func newAcceptanceTestEnv() (*accTestEnv, error) {
 		Context:     ctx,
 		Storage:     &logical.InmemStorage{},
 	}, nil
+}
+
+// NewConfiguredAcceptanceTestEnv will return an *accTestEnv that is already configured (entry point for most tests)
+func NewConfiguredAcceptanceTestEnv(t *testing.T) (e *accTestEnv) {
+	e, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create new test token
+	_, accessToken := e.createNewTestToken(t)
+
+	// setup new path configuration
+	e.UpdateConfigAdmin(t, testData{
+		"access_token": accessToken,
+		"url":          e.URL,
+	})
+
+	return
 }
 
 const rootCert string = `MIIDHzCCAgegAwIBAgIQHC4IERZbTl67GGjV8KH04jANBgkqhkiG9w0BAQ` +


### PR DESCRIPTION
This simply allows the optional setting of a username and/or description when rotating the admin token.

It still needs docs and tests.

Basic functionality:

```console
[tmcneely@local artifactory-secrets-plugin]$ vault read artifactory/config/admin
Key                    Value
---                    -----
access_token_sha256    d3edeabe961e3741ae0e1d8795f56e8e6fa1e562e257673c4367e58ef49f9c48
scope                  applied-permissions/admin
token_id               393984a5-2948-4fa6-bd91-49301decdbe4
url                    http://localhost:8082
use_expiring_tokens    false
username               vault-admin
version                7.55.10
[tmcneely@local artifactory-secrets-plugin]$ vault write artifactory/config/rotate username=tommy-dev-vault-admin description="Admin account for vault secrets engine"
Success! Data written to: artifactory/config/rotate
[tmcneely@local artifactory-secrets-plugin]$ vault read artifactory/config/admin
Key                    Value
---                    -----
access_token_sha256    f9c63ee191570be71fabd19ff0b3104e33ad4bc9b6970b4bbdfa05dca21c36b8
scope                  applied-permissions/admin
token_id               a94b7ea8-7588-4810-8853-80809642e002
url                    http://localhost:8082
use_expiring_tokens    false
username               tommy-dev-vault-admin
version                7.55.10
[tmcneely@local artifactory-secrets-plugin]$ curl -H "Authorization: Bearer $ACCESS_TOKEN"  http://localhost:8082/access/api/v1/tokens/a94b7ea8-7588-4810-8853-80809642e002
{
  "token_id" : "a94b7ea8-7588-4810-8853-80809642e002",
  "subject" : "jfac@01gykd5tha8tmk06x1sjmg1seb/users/tommy-dev-vault-admin",
  "issued_at" : 1682391447,
  "issuer" : "jfac@01gykd5tha8tmk06x1sjmg1seb",
  "description" : "Admin account for vault secrets engine",
  "refreshable" : false
}%
```

NOTE: The token description is stored in the database, but is not in the actual JWT token.


/closes #69 

