### PR TITLE
test: improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 
 .DS_Store
 dist/
-coverage.txt
+/coverage.*

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ acceptance:
 	export JFROG_ACCESS_TOKEN=$(JFROG_ACCESS_TOKEN) && \
 		go test -run TestAcceptance -cover -coverprofile=coverage.txt -v -p 1 -timeout 5m ./...
 
+alltests:
+	export VAULT_ACC=true && \
+	export JFROG_ACCESS_TOKEN=$(JFROG_ACCESS_TOKEN) && \
+		go test -cover -coverprofile=coverage.out -v -p 1 -timeout 5m ./...
+
 clean:
 	rm -f $(PLUGIN_DIR)/$(PLUGIN_FILE)
 

--- a/path_config.go
+++ b/path_config.go
@@ -104,7 +104,6 @@ func (b *backend) pathConfigUpdate(ctx context.Context, req *logical.Request, da
 	}
 
 	if val, ok := data.GetOk("use_expiring_tokens"); ok {
-		b.Logger().Warn("config update use_expiring_tokens", "use_expiring_tokens", val)
 		switch exp := val.(type) {
 		case bool:
 			config.UseExpiringTokens = exp

--- a/path_config_rotate_test.go
+++ b/path_config_rotate_test.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"testing"
 
+	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,10 +12,30 @@ func TestAcceptanceBackend_PathRotate(t *testing.T) {
 		t.SkipNow()
 	}
 
+	// Unconfigured Test
+	unconfigured, err := newAcceptanceTestEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("unconfigured", unconfigured.PathConfigRotateUnconfigured)
+
+	//Configured Tests
 	e := NewConfiguredAcceptanceTestEnv(t)
+	t.Run("zeroLengthUsername", e.PathConfigRotateZeroLengthUsername)
 	t.Run("empty", e.PathConfigRotateEmpty)
 	t.Run("withDetails", e.PathConfigRotateWithDetails)
+	// Cleanup Token
 	e.Cleanup(t)
+
+	// Failure Tests
+	t.Run("CreateTokenErr", e.PathConfigRotateCreateTokenErr)
+	t.Run("badAccessToken", e.PathConfigRotateBadAccessToken)
+}
+
+func (e *accTestEnv) PathConfigRotateUnconfigured(t *testing.T) {
+	resp, err := e.update("config/rotate", testData{})
+	assert.Contains(t, resp.Data["error"], "backend not configured")
+	assert.NoError(t, err)
 }
 
 func (e *accTestEnv) PathConfigRotateEmpty(t *testing.T) {
@@ -22,6 +43,14 @@ func (e *accTestEnv) PathConfigRotateEmpty(t *testing.T) {
 	e.UpdateConfigRotate(t, testData{}) // empty write
 	after := e.ReadConfigAdmin(t)
 	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
+}
+
+func (e *accTestEnv) PathConfigRotateZeroLengthUsername(t *testing.T) {
+	e.UpdateConfigRotate(t, testData{
+		"username": "",
+	}) // empty write
+	after := e.ReadConfigAdmin(t)
+	assert.Equal(t, "admin-vault-secrets-artifactory", after["username"])
 }
 
 func (e *accTestEnv) PathConfigRotateWithDetails(t *testing.T) {
@@ -36,4 +65,32 @@ func (e *accTestEnv) PathConfigRotateWithDetails(t *testing.T) {
 	assert.NotEqual(t, before["access_token_sha256sum"], after["access_token_sha256"])
 	assert.Equal(t, newUsername, after["username"])
 	// Not testing Description, because it is not returned in the token (yet)
+}
+
+func (e *accTestEnv) PathConfigRotateCreateTokenErr(t *testing.T) {
+	tokenId, accessToken := e.createNewNonAdminTestToken(t)
+	e.UpdateConfigAdmin(t, testData{
+		"access_token": accessToken,
+		"url":          e.URL,
+	})
+	resp, err := e.update("config/rotate", testData{})
+	assert.NotNil(t, resp)
+	assert.Contains(t, resp.Data["error"], "error creating new token")
+	assert.ErrorContains(t, err, "could not create access token")
+	e.revokeTestToken(t, e.AccessToken, tokenId)
+}
+
+func (e *accTestEnv) PathConfigRotateBadAccessToken(t *testing.T) {
+	// Forcibly set a bad token
+	entry, err := logical.StorageEntryJSON("config/admin", adminConfiguration{
+		AccessToken:    "bogus.token",
+		ArtifactoryURL: e.URL,
+	})
+	assert.NoError(t, err)
+	err = e.Storage.Put(e.Context, entry)
+	assert.NoError(t, err)
+	resp, err := e.update("config/rotate", testData{})
+	// assert.Contains(t, resp.Data["error"], "error parsing existing AccessToken")
+	assert.Contains(t, resp.Data["error"], "could not get the certificate")
+	assert.Error(t, err)
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -114,13 +114,7 @@ func (e *accTestEnv) UpdatePathConfig(t *testing.T) {
 
 // UpdateConfigAdmin will send a POST/PUT to the /config/admin endpoint with testData (vault write artifactory/config/admin)
 func (e *accTestEnv) UpdateConfigAdmin(t *testing.T, data testData) {
-	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-		Data:      data,
-	})
-
+	resp, err := e.update("config/admin", data)
 	assert.NoError(t, err)
 	assert.Nil(t, resp)
 }
@@ -131,11 +125,7 @@ func (e *accTestEnv) ReadPathConfig(t *testing.T) {
 
 // ReadConfigAdmin will send a GET to the /config/admin endpoint (vault read artifactory/config/admin)
 func (e *accTestEnv) ReadConfigAdmin(t *testing.T) testData {
-	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config/admin",
-		Storage:   e.Storage,
-	})
+	resp, err := e.read("config/admin")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -166,7 +156,16 @@ func (e *accTestEnv) UpdateConfigRotate(t *testing.T, data testData) {
 	assert.Nil(t, resp)
 }
 
-// update will send a POST.Put to "path" with testData
+// read will send a GET  to "path"
+func (e *accTestEnv) read(path string) (*logical.Response, error) {
+	return e.Backend.HandleRequest(e.Context, &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config/admin",
+		Storage:   e.Storage,
+	})
+}
+
+// update will send a POST/PUT to "path" with testData
 func (e *accTestEnv) update(path string, data testData) (*logical.Response, error) {
 	return e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.UpdateOperation,

--- a/test_utils.go
+++ b/test_utils.go
@@ -54,6 +54,33 @@ func (e *accTestEnv) createNewTestToken(t *testing.T) (string, string) {
 	return resp.TokenId, resp.AccessToken
 }
 
+// createNewNonAdminTestToken creates a new "user" token using the one from test environment
+// primarily used to fail tests
+func (e *accTestEnv) createNewNonAdminTestToken(t *testing.T) (string, string) {
+	config := adminConfiguration{
+		AccessToken:    e.AccessToken,
+		ArtifactoryURL: e.URL,
+	}
+
+	role := artifactoryRole{
+		GrantType: "client_credentials",
+		Username:  "notTheAdmin",
+		Scope:     "applied-permissions/groups:readers",
+	}
+
+	err := e.Backend.(*backend).getVersion(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := e.Backend.(*backend).CreateToken(config, role)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return resp.TokenId, resp.AccessToken
+}
+
 func (e *accTestEnv) revokeTestToken(t *testing.T, accessToken string, tokenID string) {
 	config := adminConfiguration{
 		AccessToken:    e.AccessToken,
@@ -132,17 +159,21 @@ func (e *accTestEnv) DeleteConfigAdmin(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-// UpdateConfigRotate will send a POST/PUT to the /config/rotate endpoint with testData (vault write artifactory/config/rotate)
+// UpdateConfigRotate will send a POST/PUT to the /config/rotate endpoint with testData (vault write artifactory/config/rotate) and test for errors
 func (e *accTestEnv) UpdateConfigRotate(t *testing.T, data testData) {
-	resp, err := e.Backend.HandleRequest(e.Context, &logical.Request{
+	resp, err := e.update("config/rotate", data)
+	assert.NoError(t, err)
+	assert.Nil(t, resp)
+}
+
+// update will send a POST.Put to "path" with testData
+func (e *accTestEnv) update(path string, data testData) (*logical.Response, error) {
+	return e.Backend.HandleRequest(e.Context, &logical.Request{
 		Operation: logical.UpdateOperation,
-		Path:      "config/rotate",
+		Path:      path,
 		Storage:   e.Storage,
 		Data:      data,
 	})
-
-	assert.NoError(t, err)
-	assert.Nil(t, resp)
 }
 
 func (e *accTestEnv) CreatePathRole(t *testing.T) {


### PR DESCRIPTION
Add a few error state tests to improve test coverage on config/rotate

* `path_config_rotate.go`
  * master: 77.1% (overall 62.4%)
  * this branch: 88.6% (overall 65%)