### PR TITLE
Add call home to Artifactory

### DIFF
--- a/artifactory.go
+++ b/artifactory.go
@@ -356,7 +356,6 @@ type Usage struct {
 }
 
 func (b *backend) callHome(config adminConfiguration, featureId string) {
-	b.Backend.Logger().Debug("callHome")
 	features := []Feature{
 		{
 			FeatureId: featureId,

--- a/artifactory.go
+++ b/artifactory.go
@@ -355,7 +355,7 @@ type Usage struct {
 	Features  []Feature `json:"features"`
 }
 
-func (b *backend) callHome(config adminConfiguration, featureId string) {
+func (b *backend) sendUsage(config adminConfiguration, featureId string) {
 	features := []Feature{
 		{
 			FeatureId: featureId,

--- a/artifactory.go
+++ b/artifactory.go
@@ -397,7 +397,7 @@ func (b *backend) performArtifactoryGet(config adminConfiguration, path string) 
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", "art-secrets-plugin")
+	req.Header.Set("User-Agent", productId)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
@@ -419,6 +419,7 @@ func (b *backend) performArtifactoryPost(config adminConfiguration, path string,
 		return nil, err
 	}
 
+	req.Header.Set("User-Agent", productId)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
@@ -441,6 +442,7 @@ func (b *backend) performArtifactoryPostWithJSON(config adminConfiguration, path
 		return nil, err
 	}
 
+	req.Header.Set("User-Agent", productId)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/json")
 
@@ -465,7 +467,7 @@ func (b *backend) performArtifactoryDelete(config adminConfiguration, path strin
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", "art-secrets-plugin")
+	req.Header.Set("User-Agent", productId)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", config.AccessToken))
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 

--- a/artifactory.go
+++ b/artifactory.go
@@ -26,7 +26,6 @@ const (
 var ErrIncompatibleVersion = errors.New("incompatible version")
 
 func (b *backend) RevokeToken(config adminConfiguration, secret logical.Secret) error {
-
 	accessToken := secret.InternalData["access_token"].(string)
 	tokenId := secret.InternalData["token_id"].(string)
 
@@ -345,6 +344,44 @@ func (b *backend) getRootCert(config adminConfiguration) (cert *x509.Certificate
 		return
 	}
 	return
+}
+
+type Feature struct {
+	FeatureId string `json:"featureId"`
+}
+
+type Usage struct {
+	ProductId string    `json:"productId"`
+	Features  []Feature `json:"features"`
+}
+
+func (b *backend) callHome(config adminConfiguration, featureId string) {
+	b.Backend.Logger().Debug("callHome")
+	features := []Feature{
+		{
+			FeatureId: featureId,
+		},
+	}
+
+	usage := Usage{
+		productId,
+		features,
+	}
+
+	jsonReq, err := json.Marshal(usage)
+	if err != nil {
+		b.Backend.Logger().Info("error marshalling call home request", "err", err)
+		return
+	}
+
+	resp, err := b.performArtifactoryPostWithJSON(config, "artifactory/api/system/usage", jsonReq)
+	if err != nil {
+		b.Backend.Logger().Info("error making call home request", "response", resp, "err", err)
+		return
+	}
+
+	//noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
 }
 
 func (b *backend) performArtifactoryGet(config adminConfiguration, path string) (*http.Response, error) {

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -17,10 +17,7 @@ func TestBackend_CreateTokenSuccess(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -75,10 +72,7 @@ func TestBackend_CreateTokenArtifactoryUnavailable(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -124,10 +118,7 @@ func TestBackend_CreateTokenUnauthorized(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -175,10 +166,7 @@ func TestBackend_CreateTokenArtifactoryMisconfigured(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -224,10 +212,7 @@ func TestBackend_RevokeToken(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -289,10 +274,7 @@ func TestBackend_RotateAdminToken(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, `{"version" : "7.33.8", "revision" : "73308900"}`))
+	mockArtifactoryUsageVersionRequests(`{"version" : "7.33.8", "revision" : "73308900"}`)
 
 	httpmock.RegisterResponder(
 		"GET",

--- a/backend.go
+++ b/backend.go
@@ -13,6 +13,7 @@ import (
 )
 
 var Version = "v1.0.0"
+var productId = "vault-plugin-secrets-artifactory/" + Version[1:] // don't need the 'v' prefix in productId
 
 type backend struct {
 	*framework.Backend

--- a/path_config.go
+++ b/path_config.go
@@ -124,7 +124,7 @@ func (b *backend) pathConfigUpdate(ctx context.Context, req *logical.Request, da
 		return logical.ErrorResponse("url is required"), nil
 	}
 
-	go b.callHome(*config, "pathConfigRotateUpdate")
+	go b.sendUsage(*config, "pathConfigRotateUpdate")
 
 	err = b.getVersion(*config)
 	if err != nil {
@@ -157,7 +157,7 @@ func (b *backend) pathConfigDelete(ctx context.Context, req *logical.Request, _ 
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathConfigDelete")
+	go b.sendUsage(*config, "pathConfigDelete")
 
 	if err := req.Storage.Delete(ctx, "config/admin"); err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (b *backend) pathConfigRead(ctx context.Context, req *logical.Request, _ *f
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathConfigRead")
+	go b.sendUsage(*config, "pathConfigRead")
 
 	// I'm not sure if I should be returning the access token, so I'll hash it.
 	accessTokenHash := sha256.Sum256([]byte(config.AccessToken))

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -46,7 +46,7 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathConfigRotateWrite")
+	go b.sendUsage(*config, "pathConfigRotateWrite")
 
 	oldAccessToken := config.AccessToken
 

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -46,6 +46,8 @@ func (b *backend) pathConfigRotateWrite(ctx context.Context, req *logical.Reques
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
+	go b.callHome(*config, "pathConfigRotateWrite")
+
 	oldAccessToken := config.AccessToken
 
 	// Parse Current Token (to get tokenID/scope)

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -73,10 +73,8 @@ func TestBackend_AccessTokenAsSHA256(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
+
 	httpmock.RegisterResponder(
 		"GET",
 		"http://myserver.com:80/access/api/v1/cert/root",

--- a/path_roles.go
+++ b/path_roles.go
@@ -114,7 +114,7 @@ func (b *backend) pathRoleWrite(ctx context.Context, req *logical.Request, data 
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathRoleWrite")
+	go b.sendUsage(*config, "pathRoleWrite")
 
 	roleName := data.Get("role").(string)
 
@@ -192,7 +192,7 @@ func (b *backend) pathRoleRead(ctx context.Context, req *logical.Request, data *
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathRoleRead")
+	go b.sendUsage(*config, "pathRoleRead")
 
 	roleName := data.Get("role").(string)
 
@@ -270,7 +270,7 @@ func (b *backend) pathRoleDelete(ctx context.Context, req *logical.Request, data
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathRoleDelete")
+	go b.sendUsage(*config, "pathRoleDelete")
 
 	err = req.Storage.Delete(ctx, "roles/"+data.Get("role").(string))
 	if err != nil {

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -70,10 +70,7 @@ func TestBackend_PathRoleList_AddRole(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	b, config := configuredBackend(t, map[string]interface{}{
 		"access_token": "test-access-token",
@@ -102,10 +99,7 @@ func TestBackend_PathRoleListReturnsRole(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	b, config := configuredBackend(t, map[string]interface{}{
 		"access_token": "test-access-token",
@@ -145,10 +139,7 @@ func TestBackend_PathRoleWriteThenRead(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	b, config := configuredBackend(t, map[string]interface{}{
 		"access_token": "test-access-token",

--- a/path_token_create.go
+++ b/path_token_create.go
@@ -62,6 +62,8 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
+	go b.callHome(*config, "pathTokenCreatePerform")
+
 	// Read in the requested role
 	roleName := data.Get("role").(string)
 

--- a/path_token_create.go
+++ b/path_token_create.go
@@ -62,7 +62,7 @@ func (b *backend) pathTokenCreatePerform(ctx context.Context, req *logical.Reque
 		return logical.ErrorResponse("backend not configured"), nil
 	}
 
-	go b.callHome(*config, "pathTokenCreatePerform")
+	go b.sendUsage(*config, "pathTokenCreatePerform")
 
 	// Read in the requested role
 	roleName := data.Get("role").(string)

--- a/test_utils.go
+++ b/test_utils.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/helper/logging"
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -338,4 +339,21 @@ func configuredBackend(t *testing.T, adminConfig map[string]interface{}) (*backe
 	assert.NoError(t, err)
 
 	return b, config
+}
+
+func mockArtifactoryUsageVersionRequests(version string) {
+	versionString := version
+	if len(version) == 0 {
+		versionString = artVersion
+	}
+
+	httpmock.RegisterResponder(
+		"POST",
+		"http://myserver.com:80/artifactory/api/system/usage",
+		httpmock.NewStringResponder(200, ""))
+	httpmock.RegisterResponder(
+		"GET",
+		"http://myserver.com:80/artifactory/api/system/version",
+		httpmock.NewStringResponder(200, versionString))
+
 }

--- a/ttl_test.go
+++ b/ttl_test.go
@@ -18,10 +18,7 @@ func TestBackend_NoRoleMaxTTLUsesSystemMaxTTL(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",
@@ -75,10 +72,7 @@ func TestBackend_WorkingWithBothMaxTTLs(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder(
-		"GET",
-		"http://myserver.com:80/artifactory/api/system/version",
-		httpmock.NewStringResponder(200, artVersion))
+	mockArtifactoryUsageVersionRequests("")
 
 	httpmock.RegisterResponder(
 		"POST",


### PR DESCRIPTION
Call home request does not contain any data from the users. It sends only the product ID (e.g. `vault-plugin-secrets-artifactory/0.2.18`) and the Vault actions (e.g. `pathConfigRotateUpdate`) to Artifactory call home API endpoint.

Also fixes #90