### PR TITLE
fix: jq to select latest version

### DIFF
--- a/scripts/run-artifactory-container.sh
+++ b/scripts/run-artifactory-container.sh
@@ -14,7 +14,7 @@ if [ $ARTIFACTORY_VERSION == "latest" ]; then
   REPO_HOST=$(echo $ARTIFACTORY_REPO | cut -d/ -f1)
   REPO_PATH=$(echo $ARTIFACTORY_REPO | cut -d/ -f2-)
   ARTIFACTORY_VERSION=$(curl -u anonymous: -sS "https://${REPO_HOST}/v2/${REPO_PATH}/${ARTIFACTORY_IMAGE}/tags/list" \
-    | jq -er '.tags | map(select(. | index("latest") | not)) | sort_by(values | split(".") | map(tonumber)) | last')
+    | jq -er '.tags | map(select(. | test("^[0-9.]+"))) | sort_by(values | split(".") | map(tonumber)) | last')
 fi
 
 echo "ARTIFACTORY_IMAGE=${ARTIFACTORY_IMAGE}" > /dev/stderr


### PR DESCRIPTION
Related to #48 ... was testing against artifactory-pro, but it failed due to "sha256" tags, so this is a better pattern match for "version" like tags.


Now it works with artifactory-pro:

```console
[tmcneely@local artifactory-secrets-plugin]$ ARTIFACTORY_IMAGE=artifactory-pro ARTIFACTORY_VERSION=latest ./scripts/run-artifactory-container.sh
ARTIFACTORY_IMAGE=artifactory-pro
ARTIFACTORY_VERSION=7.55.4
Unable to find image 'releases-docker.jfrog.io/jfrog/artifactory-pro:7.55.4' locally
7.55.4: Pulling from jfrog/artifactory-pro
#...
```

On a side note, I am 99% sure we are using 7.55.10, but the latest published image tag in the jfrog docker repo shows 7.55.4? 

I find that a bit strange :)

~tommy