### PR TITLE
Set GoRelease to archive the binary only

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,8 +32,7 @@ builds:
 snapshot:
   name_template: '{{ .Version }}'
 archives:
-  - format: zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - format: binary
 signs:
   - artifacts: checksum
     args:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ export VAULT_ADDR ?= http://localhost:8200
 all: fmt build test start
 
 build: fmt
-	GORELEASER_CURRENT_TAG=$(NEXT_VERSION) goreleaser build --single-target --clean --snapshot
+	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --clean --snapshot
+
+release:
+	goreleaser release --clean --snapshot --parallelism 2
 
 start:
 	vault server -dev -dev-root-token-id=root -dev-plugin-dir=$(PLUGIN_DIR) -log-level=DEBUG


### PR DESCRIPTION
Closes #81 

Instead of creating a zip file containing the binary. This allows the generation of checksum of the binaries and then a signature file for the checksums file.